### PR TITLE
fix(worker): resolve build failure by removing Node.js dependency

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -26,6 +26,7 @@ interface Project {
 	RECRUITER_WHITELIST_EMAIL?: string; // Added for recruiter whitelist
 	VITE_WORKER_URL?: string; // Added VITE_WORKER_URL	        // Ensure this KV namespace is bound in your worker's environment.
 	        // If not bound, embedding-related functionalities will be disabled or throw errors.
+	ENVIRONMENT?: string;
 }
 
 interface ContactFormRequest {

--- a/worker/src/rateLimiter.ts
+++ b/worker/src/rateLimiter.ts
@@ -25,7 +25,7 @@ const MAX_REQUESTS_PER_WINDOW = 10; // Max 10 requests per minute per IP
  */
 export async function checkRateLimit(ip: string, env: Env): Promise<{ allowed: boolean; retryAfter?: number }> {
 	// Bypass rate limiting entirely if in test environment
-	if (process.env.NODE_ENV === 'test') {
+	if (env.ENVIRONMENT === 'test') {
 		console.log('Rate limiting bypassed for test environment.');
 		return { allowed: true };
 	}

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -8,6 +8,9 @@ export default defineConfig({
         wrangler: { configPath: './wrangler.toml' },
         miniflare: {
           kvNamespaces: ['RATE_LIMIT_KV', 'PROJECT_EMBEDDINGS_KV'], // Explicitly define KV namespaces
+          bindings: {
+            ENVIRONMENT: 'test',
+          },
         },
         singleWorker: true, // Experiment with reusing worker instance
       },


### PR DESCRIPTION
Replaced the Node.js-specific `process.env.NODE_ENV` with a Cloudflare Workers-compatible environment variable to resolve the build failure.

- Added an optional `ENVIRONMENT` property to the `Env` interface.
- Updated the rate limiter to check for `env.ENVIRONMENT === 'test'`.
- Configured the test environment to set the `ENVIRONMENT` variable.