### PR TITLE
Fix worker build error

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -48,9 +48,10 @@ jobs:
 
       - name: Deploy Worker (prod)
         id: deploy_worker_step
+        working-directory: ./worker
         run: |
-          echo "Running command: npx wrangler deploy worker/dist/index.js -c worker/wrangler.toml --env production --var RATE_LIMIT_KV_ID:${{ secrets.RATE_LIMIT_KV_ID }} --var PROJECT_EMBEDDINGS_KV_ID:${{ secrets.PROJECT_EMBEDDINGS_KV_ID }}"
-          npx wrangler deploy worker/dist/index.js -c worker/wrangler.toml --env production --var RATE_LIMIT_KV_ID:${{ secrets.RATE_LIMIT_KV_ID }} --var PROJECT_EMBEDDINGS_KV_ID:${{ secrets.PROJECT_EMBEDDINGS_KV_ID }}
+          echo "Running command: npx wrangler deploy dist/index.js -c wrangler.toml --env production --var RATE_LIMIT_KV_ID:${{ secrets.RATE_LIMIT_KV_ID }} --var PROJECT_EMBEDDINGS_KV_ID:${{ secrets.PROJECT_EMBEDDINGS_KV_ID }}"
+          npx wrangler deploy dist/index.js -c wrangler.toml --env production --var RATE_LIMIT_KV_ID:${{ secrets.RATE_LIMIT_KV_ID }} --var PROJECT_EMBEDDINGS_KV_ID:${{ secrets.PROJECT_EMBEDDINGS_KV_ID }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -58,6 +59,7 @@ jobs:
           PROJECT_EMBEDDINGS_KV_ID: ${{ secrets.PROJECT_EMBEDDINGS_KV_ID }}
 
       - name: Set Secrets for Wrangler (prod)
+        working-directory: ./worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -69,8 +71,8 @@ jobs:
             exit 1
           fi
           # Put secrets into the account + use the production wrangler config explicitly
-          echo "$GEMINI_API_KEY" | npx wrangler secret put GEMINI_API_KEY --name ai-powered-static-portfolio-worker-production -c worker/wrangler.toml --env production
-          echo "$ALLOWED_ORIGINS" | npx wrangler secret put ALLOWED_ORIGINS --name ai-powered-static-portfolio-worker-production -c worker/wrangler.toml --env production
+          echo "$GEMINI_API_KEY" | npx wrangler secret put GEMINI_API_KEY --name ai-powered-static-portfolio-worker-production -c wrangler.toml --env production
+          echo "$ALLOWED_ORIGINS" | npx wrangler secret put ALLOWED_ORIGINS --name ai-powered-static-portfolio-worker-production -c wrangler.toml --env production
 
   deploy-frontend:
     needs: deploy-worker

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test:e2e": "cross-env DEBUG=pw:webserver npx playwright test",
-    "deploy": "npm install --prefix worker && wrangler deploy worker/src/index.ts"
+    "deploy": "npm install --prefix worker && wrangler deploy --env production --var RATE_LIMIT_KV_ID:$RATE_LIMIT_KV_ID --var PROJECT_EMBEDDINGS_KV_ID:$PROJECT_EMBEDDINGS_KV_ID worker/src/index.ts"
   },
   "dependencies": {
     "@sentry/browser": "^10.17.0",

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -18,4 +18,16 @@ RECRUITER_WHITELIST_EMAIL = ""
 port = 8787
 inspector_port = 0
 
+[env.production]
+name = "ai-powered-static-portfolio-worker-production"
+kv_namespaces = [
+  { binding = "RATE_LIMIT_KV", id = "${RATE_LIMIT_KV_ID}" },
+  { binding = "PROJECT_EMBEDDINGS_KV", id = "${PROJECT_EMBEDDINGS_KV_ID}" }
+]
+
+[env.production.vars]
+ALLOWED_ORIGINS = "https://gmpho.github.io/AI-powered-Static-portfolio/"
+PROJECT_SEARCH_SIMILARITY_THRESHOLD = "0.7"
+RECRUITER_WHITELIST_EMAIL = ""
+
 


### PR DESCRIPTION
fix(ci): set working directory for wrangler commands

Set the working directory to `./worker` for the "Deploy Worker (prod)" and "Set Secrets for Wrangler (prod)" steps in the GitHub Actions workflow.

This ensures that the `wrangler` command is executed from the same directory as the `wrangler.toml` file, preventing any potential pathing issues and ensuring that the configuration file is read correctly.🔜🚀