### PR TITLE
fix: Correct wrangler deploy command in static.yml

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --config ./worker/wrangler.toml
+          command: deploy
           workingDirectory: ./worker
           environment: production
         env:


### PR DESCRIPTION
The deploy command for the Cloudflare Worker was failing because the --config flag was pointing to a path that did not exist within the specified workingDirectory.

By removing the --config flag, the wrangler-action correctly uses the wrangler.toml file from the workingDirectory.