### PR TITLE
fix: Pass KV namespace bindings via CLI flags in deploy workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --config ./worker/wrangler.toml
+          command: deploy --kv RATE_LIMIT_KV=$RATE_LIMIT_KV_ID --kv PROJECT_EMBEDDINGS_KV=$PROJECT_EMBEDDINGS_KV_ID
           workingDirectory: ./worker
           environment: production
         env:


### PR DESCRIPTION
The Cloudflare Worker deployment was failing with the error "KV namespace '${VAR}' is not valid" because environment variable substitution was not working correctly for the `kv_namespaces` in `wrangler.toml` within the GitHub Actions environment.

This commit modifies the `wrangler deploy` command to pass the KV namespace bindings directly using the `--kv` command-line flag. This approach bypasses the file-based variable substitution and ensures the bindings are correctly resolved at deployment time.