### PR TITLE
fix(deploy): Pass KV bindings as flags in deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -43,12 +43,9 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
+          command: deploy --kv RATE_LIMIT_KV=${{ secrets.RATE_LIMIT_KV_ID }} --kv PROJECT_EMBEDDINGS_KV=${{ secrets.PROJECT_EMBEDDINGS_KV_ID }}
           workingDirectory: ./worker
           environment: production
-        env:
-          RATE_LIMIT_KV_ID: ${{ secrets.RATE_LIMIT_KV_ID }}
-          PROJECT_EMBEDDINGS_KV_ID: ${{ secrets.PROJECT_EMBEDDINGS_KV_ID }}
 
 
 


### PR DESCRIPTION
Passes the KV namespace bindings directly to the `wrangler deploy` command as command-line flags. This is a more robust and explicit method than relying on environment variable substitution in the `wrangler.toml` file, which can be unreliable in the `cloudflare/wrangler-action` GitHub Action.